### PR TITLE
Add 'file-logger' to the dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ asciidoctor {
         asciidoctor 'org.asciidoctor:asciidoctorj-diagram:1.5.12'
         asciidoctor 'fr.jmini.asciidoctorj:git-link:3.1.0'
         asciidoctor 'fr.jmini.asciidoctorj:sourcedir:1.1.0'
+        asciidoctor 'fr.jmini.asciidoctorj:file-logger:1.0.0'
     }
 }
 


### PR DESCRIPTION
This PR add [file-logger](https://jmini.github.io/asciidoctorj-file-logger/) to the build file.

This allows displaying asciidoctor issues in Jenkins:

<img width="547" alt="Asciidoctor warnings in Jenkins" src="https://user-images.githubusercontent.com/1222165/56111907-baaae200-5f59-11e9-82ea-3c284b81816e.png">
